### PR TITLE
build(deps): Use actuated for arm (and RISC-V) builds

### DIFF
--- a/.github/workflows/multibuild.yaml
+++ b/.github/workflows/multibuild.yaml
@@ -11,15 +11,7 @@ permissions:  # added using https://github.com/step-security/secure-repo
 
 jobs:
   x64_build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        include:
-          - os: actuated
-            output-name: sshnp-linux-x64
-
+    runs-on: actuated
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.5.0
@@ -30,22 +22,39 @@ jobs:
       - run: dart compile exe bin/sshnp.dart -v -o sshnp/sshnp
       - run: dart compile exe bin/sshnpd.dart -v -o sshnp/sshnpd
       - run: cp scripts/* sshnp
-      - run: tar -cvzf tarball/${{ matrix.output-name }}.tgz sshnp
+      - run: tar -cvzf tarball/sshnp-linux-x64.tgz sshnp
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: x64_binaries
+          name: x64_binary
           path: tarball
-  
-  other_build:
-    runs-on: ubuntu-latest
+ 
+  arm64_build:
+    runs-on: actuated-aarch64
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.5.0
+      - run: mkdir sshnp
+      - run: mkdir tarball
+      - run: dart pub get
+      - run: dart compile exe bin/activate_cli.dart -v -o sshnp/at_activate
+      - run: dart compile exe bin/sshnp.dart -v -o sshnp/sshnp
+      - run: dart compile exe bin/sshnpd.dart -v -o sshnp/sshnpd
+      - run: cp scripts/* sshnp
+      - run: tar -cvzf tarball/sshnp-linux-arm64.tgz sshnp
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: arm64_binary
+          path: tarball
 
+  other_build:
+    runs-on: actuated-aarch64
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
       - uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2.5.0
       - run: |
           docker buildx build -t atsigncompany/sshnptarball -f Dockerfile.package \
-          --platform linux/arm/v7,linux/arm64,linux/riscv64 -o type=tar,dest=bins.tar .
+          --platform linux/arm/v7,linux/riscv64 -o type=tar,dest=bins.tar .
       - run: mkdir tarballs
       - run: tar -xvf bins.tar -C tarballs
       - run: mkdir upload


### PR DESCRIPTION
Hi @alexellis 

PR as you suggested by DM yesterday

If I should be using a matrix for the x64 and arm64 native builds then I'd love to know the best approach to that, but for now I don't mind a bit of repetition

I wasn't sure how best to do the armv7 build, but I thought perhaps using buildx on top of arm64 might be optimal.

That just leaves RISC-V, which is going to need QEMU, and I'm just hoping that emulation of one RISC ISA on top of another might be better than running it on x64?